### PR TITLE
refactorizar gestion de usuarios quitando id_usuario

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "parse": "^6.1.1"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ app.use("/users", userRoutes);
 
 // Ruta base
 app.get("/", (req, res) => {
-  res.send("API funcionando");
+  res.send("Servidor Web funcionando");
 });
 
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -13,9 +13,8 @@ const getUsers = async (req, res) => {
 // POST /users
 const createUser = async (req, res) => {
   try {
-    const { userId, name, email, password } = req.body;    
-    console.log("Datos", userId, name, email, password);
-    const newUser = await userService.addUser({userId, name, email, password});
+    const { name, email, password } = req.body;    
+    const newUser = await userService.addUser({ name, email, password});
     res.status(201).json(newUser.toJSON());
   } catch (error) {
     res.status(400).json({ message: error.message });
@@ -64,4 +63,18 @@ const deleteUser = async (req, res) => {
   }
 };
 
-module.exports = { getUsers, createUser, getUserByEmail, updateUser, deleteUser };
+const getUserID = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const objectId = await userService.getUserObjectId(email, password);
+    if (!objectId) {
+      return res.status(404).json({ message: "Invalid email or password" });
+    }
+    res.json({ objectId });
+  } catch (error) { 
+    res.status(400).json({ message: error.message });
+  }
+};
+
+
+module.exports = {getUserID, getUsers, createUser, getUserByEmail, updateUser, deleteUser };

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,0 +1,30 @@
+//De momento no se utilizará, pero se tendrá en cuenta 
+// para endponits sensibles
+const jwt = require("jsonwebtoken");
+
+const authMiddleware = (requiredRole) => {
+  return (req, res, next) => {
+    const token = req.headers.authorization?.split(" ")[1];
+    if (!token) return res.status(401).json({ message: "No token provided" });
+
+    try {
+      const payload = jwt.verify(token, process.env.JWT_SECRET);
+      if (requiredRole && payload.role !== requiredRole) {
+        return res.status(403).json({ message: "No autorizado" });
+      }
+
+      req.userId = payload.userId;
+      req.userRole = payload.role;
+      next();
+    } catch (error) {
+      return res.status(401).json({ message: "Token inválido" });
+    }
+  };
+};
+
+module.exports = {authMiddleware};
+
+
+//para firmar
+//const token = jwt.sign({ userId, role }, process.env.JWT_SECRET, { expiresIn: "1h" });
+

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -1,10 +1,16 @@
 // src/models/userModel.js
 class User {
-    constructor(id, name, email) {
-        this.id = id;
+    constructor(name, email) {
         this.name = name;
         this.email = email;
     }
+
+    toJSON() {
+    return {
+      name: this.name,
+      email: this.email
+    };
+  }
 }
 
 module.exports = User;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,11 +1,13 @@
+const middlewares = require("../middlewares/authMiddleware"); 
 const express = require('express');
 const router = express.Router();
-const { getUsers, createUser, getUserByEmail,updateUser, deleteUser} = require('../controllers/userController');
+const {getUserID, getUsers, createUser, getUserByEmail,updateUser, deleteUser} = require('../controllers/userController');
 
 router.get('/', getUsers);
 router.post('/', createUser);
 router.get('/email/:email', getUserByEmail); 
 router.put('/:id', updateUser);           
 router.delete('/:id', deleteUser); 
+router.post("/getUserID",middlewares.authMiddleware("admin"),getUserID);
 
 module.exports = router;


### PR DESCRIPTION
En este PR se ha eliminado el uso de id_usuario para todas las funcionalidades relacionadas con la gestión del usuario. Como identificador se usará objectId. Además, la API devuelve solo los campos necesarios del usuario, utilizando para ello el UserModel. 